### PR TITLE
[PoolRequest] make callback optional

### DIFF
--- a/lib/PoolRequest.js
+++ b/lib/PoolRequest.js
@@ -7,6 +7,8 @@
  */
 'use strict';
 
+function noop() {}
+
 class PoolRequest {
 
   /**
@@ -16,7 +18,7 @@ class PoolRequest {
    */
   constructor(pool, callback) {
     this.created = Date.now();
-    this.callback = callback;
+    this.callback = callback || noop;
     this.pool = pool;
     if (pool.options.acquireTimeoutMillis) {
       this.timeoutHandle = setTimeout(() => {


### PR DESCRIPTION
Pool._ensureMin does not provide a callback to the PoolRequest
constructor. This causes an uncaught exception to be thrown by nodejs.